### PR TITLE
修改README以及plugin.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![CodeSize](https://img.shields.io/github/languages/code-size/carm-outsource/QuickShop-Hikari-Cracker)
 [![Download](https://img.shields.io/github/downloads/carm-outsource/QuickShop-Hikari-Cracker/total)](https://github.com/carm-outsource/QuickShop-Hikari-Cracker/releases)
 [![Java CI with Maven](https://github.com/carm-outsource/QuickShop-Hikari-Cracker/actions/workflows/maven.yml/badge.svg?branch=master)](https://github.com/carm-outsource/QuickShop-Hikari-Cracker/actions/workflows/maven.yml)
-![Support](https://img.shields.io/badge/Minecraft-Java%201.13--Latest-blue)
+![Support](https://img.shields.io/badge/Minecraft-Java%201.18--Latest-blue)
 ![](https://visitor-badge.glitch.me/badge?page_id=quickshop-hikari-cracker.readme)
 
 这似乎是一个可以绕过 QuickShop-Hikari 最新版对中国大陆使用限制的插件。

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ author: CarmJos
 website: ${project.url}
 description: ${project.description}
 
-api-version: 1.13
+api-version: 1.18
 
 loadbefore:
   - QuickShop-Hikari


### PR DESCRIPTION
QuickShop-Hikari 仅支持版本1.18+，虽然破解插件可以在1.13+运行...